### PR TITLE
Disable dataroaming by default

### DIFF
--- a/target/product/full_base_telephony.mk
+++ b/target/product/full_base_telephony.mk
@@ -20,8 +20,7 @@
 # entirely appropriate to inherit from for on-device configurations.
 
 PRODUCT_PROPERTY_OVERRIDES := \
-    keyguard.no_require_sim=true \
-    ro.com.android.dataroaming=true
+    keyguard.no_require_sim=true
 
 PRODUCT_COPY_FILES := \
     frameworks/native/data/etc/handheld_core_hardware.xml:system/etc/permissions/handheld_core_hardware.xml


### PR DESCRIPTION
The property is removed so that the property in vendor/cm can
take effect

Change-Id: Iefadc1a6e71cbf92ecb7363c953f4b5a82064446